### PR TITLE
update: 更新readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,9 @@ $gio = GrowingIO::getInstance($accountID, $host, $dataSourceId, $props);
 |loginUserId|true|string| |登录用户id|
 |eventKey|true|string| |事件名, 事件标识符|
 |properties|false|array|array()|事件发生时,所伴随的维度信息|
-|id|false|string|null|事件发生时关联的物品模型id|
-|key|false|string|null|事件发生时关联的物品模型key|
 ###### 示例
 ```php
 $gio->trackCustomEvent($gio->getCustomEventFactory('loginUserId', 'eventName')
-    ->setKey('itemKey')
-    ->setId('itemId')
     ->setLoginUserKey('loginUserKey')
     ->setProperties(array('attrKey1' => 'attrValue1', 'attrKey2' => 'attrValue2'))
     ->create()

--- a/example/Demo.php
+++ b/example/Demo.php
@@ -24,23 +24,19 @@ function currentMillisecond()
 
 $start = currentMillisecond();
 printf($start . PHP_EOL);
-$gio->track('phpUserId', 'phpEvent');
 $gio->setUserAttributes('phpUserId', array('userKey1' => 'v1', 'userKey2' => 'v2'));
 $gio->setUserAttributesEvent($gio->getUserAttributesFactory('pUserId')
     ->setLoginUserKey('pUserKey')
     ->setProperties(array('userKey1' => 'v1', 'userKey2' => 'v2'))
     ->create());
 $gio->setUserAttributesEvent($gio->getUserAttributesFactory('pUserId')->create());
+$gio->track('phpUserId', 'phpEvent');
 $gio->track(
     'phpUserId',
     'phpEvent',
-    array('userKey1' => 'v1', 'userKey2' => 'v2'),
-    '1',
-    'phpKey'
+    array('userKey1' => 'v1', 'userKey2' => 'v2')
 );
 $gio->trackCustomEvent($gio->getCustomEventFactory('loginUserId', 'pEvent')
-    ->setKey('itemKey')
-    ->setId('itemId')
     ->setLoginUserKey('loginUserKey')
     ->setProperties(array('userKey1' => 'v1', 'userKey2' => 'v2'))
     ->create()


### PR DESCRIPTION
PR 内容
更新README，版本号为1.0.1
保持向前兼容，但是不在文档中提示自定义事件接口中上报物品模型

测试步骤
无

影响范围
无

是否属于重要变动？
[ ] 是
[ ] 否

其他信息
无