### PR TITLE
feat: 支持设置sendtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $gio = GrowingIO::getInstance($accountID, $host, $dataSourceId, $props);
 ###### 请求参数
 |参数|必选|类型|默认值|说明|
 |:----|:----|:----|:----|-----|
+|evnetTime|false|int|当前时间的时间戳|事件发生时间。如需要开启"自定义event_time上报"的功能开关，请联系技术支持|
 |loginUserKey|false|string| |登录用户类型|
 |loginUserId|true|string| |登录用户id|
 |eventKey|true|string| |事件名, 事件标识符|
@@ -58,6 +59,7 @@ $gio = GrowingIO::getInstance($accountID, $host, $dataSourceId, $props);
 ###### 示例
 ```php
 $gio->trackCustomEvent($gio->getCustomEventFactory('loginUserId', 'eventName')
+    ->setEventTime(1648524854000)
     ->setLoginUserKey('loginUserKey')
     ->setProperties(array('attrKey1' => 'attrValue1', 'attrKey2' => 'attrValue2'))
     ->create()

--- a/example/Demo.php
+++ b/example/Demo.php
@@ -26,6 +26,7 @@ $start = currentMillisecond();
 printf($start . PHP_EOL);
 $gio->setUserAttributes('phpUserId', array('userKey1' => 'v1', 'userKey2' => 'v2'));
 $gio->setUserAttributesEvent($gio->getUserAttributesFactory('pUserId')
+    ->setEventTime((time() - 24 * 60 * 60) * 1000)
     ->setLoginUserKey('pUserKey')
     ->setProperties(array('userKey1' => 'v1', 'userKey2' => 'v2'))
     ->create());
@@ -37,6 +38,7 @@ $gio->track(
     array('userKey1' => 'v1', 'userKey2' => 'v2')
 );
 $gio->trackCustomEvent($gio->getCustomEventFactory('loginUserId', 'pEvent')
+    ->setEventTime((time() - 24 * 60 * 60) * 1000)
     ->setLoginUserKey('loginUserKey')
     ->setProperties(array('userKey1' => 'v1', 'userKey2' => 'v2'))
     ->create()

--- a/test/UnitTest.php
+++ b/test/UnitTest.php
@@ -52,11 +52,14 @@ class UnitTest extends TestCase
                     'userKey' => 'userKey',
                     'userId' => 'userId',
                     'eventType' => 'CUSTOM',
-                    'dataSourceId' => '12345678'],
+                    'dataSourceId' => '12345678',
+                    'timestamp' => '1648524854000',
+                    'sendTime' => '1648524854000'],
                 $data
             );
         });
         self::$gio->trackCustomEvent(self::$gio->getCustomEventFactory('userId', "eventKey")
+                                                ->setEventTime(1648524854000)
                                                 ->setLoginUserKey('userKey')
                                                 ->create());
     }
@@ -123,11 +126,14 @@ class UnitTest extends TestCase
                 ['userId' => 'userId',
                     'eventType' => 'LOGIN_USER_ATTRIBUTES',
                     'dataSourceId' => '12345678',
+                    'timestamp' => '1648524854000',
+                    'sendTime' => '1648524854000',
                     'attributes' => array('userKey1' => 'v1', 'userKey2' => 'v2')],
                 $data
             );
         });
         self::$gio->setUserAttributesEvent(self::$gio->getUserAttributesFactory('userId')
+                                                    ->setEventTime(1648524854000)
                                                     ->setLoginUserKey('userKey')
                                                     ->setProperties(array('userKey1' => 'v1', 'userKey2' => 'v2'))
                                                     ->create());


### PR DESCRIPTION
## PR 内容
event_time设置同时设置给client_time和event_time

## 测试步骤
发送sendtime字段到cdp测试平台，数据库查数对照client_time和event_time

## 影响范围
事件可设置字段增加

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息
client_time 在这种情况下无法用来确认具体的发送时间
库中client_time与event_time相同的场景为用户导入数据或服务端sdk主动设置的时间的时间

