### PR TITLE
fix: jsonSerialize has return type after 8.0

### DIFF
--- a/src/GrowingIO.php
+++ b/src/GrowingIO.php
@@ -5,6 +5,7 @@ namespace com\growingio;
 // @codingStandardsIgnoreLine
 trait JsonSerializableTrait
 {
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [];


### PR DESCRIPTION
Return type of com\growingio\CustomEvent::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize()